### PR TITLE
Add std math translation

### DIFF
--- a/docs/conversion_patterns.md
+++ b/docs/conversion_patterns.md
@@ -305,6 +305,8 @@ with open("file.txt") as f:
 | Python | C++ |
 |--------|-----|
 | `math.sqrt(x)` | `std::sqrt(x)` |
+| `math.sin(x)` | `std::sin(x)` |
+| `math.cos(x)` | `std::cos(x)` |
 | `random.random()` | `std::uniform_real_distribution<double>(0.0, 1.0)(generator)` |
 | `len(container)` | `container.size()` |
 | `min(a, b)` | `std::min(a, b)` |

--- a/src/analyzer/code_analyzer.py
+++ b/src/analyzer/code_analyzer.py
@@ -95,6 +95,21 @@ class CodeAnalyzer:
     def _infer_variable_type(self, node: ast.Assign) -> None:
         """Infer the type of a variable assignment."""
         # Basic type inference implementation
+        target = node.targets[0]
+
+        # Handle tuple assignments early to avoid attribute errors when
+        # accessing `.id` on a tuple target. This covers patterns like
+        # `a, b = 0, 1` as well as nested tuples.
+        if isinstance(target, ast.Tuple):
+            if isinstance(node.value, ast.Tuple):
+                for t, v in zip(target.elts, node.value.elts):
+                    if isinstance(t, ast.Name):
+                        self.type_info[t.id] = self._infer_expression_type(v)
+            else:
+                for t in target.elts:
+                    if isinstance(t, ast.Name):
+                        self.type_info[t.id] = self._infer_expression_type(node.value)
+            return
         if isinstance(node.value, ast.Constant):
             if isinstance(node.value.value, (int, float)):
                 self.type_info[node.targets[0].id] = 'int' if isinstance(node.value.value, int) else 'double'

--- a/src/converter/code_generator.py
+++ b/src/converter/code_generator.py
@@ -86,7 +86,7 @@ class CodeGenerator:
         with open(output_dir / "setup.py", "w") as f:
             f.write('\n'.join(setup_content))
     
-    def _generate_header(self, analysis_result: Dict) -> str:
+    def _generate_header(self, analysis_result: AnalysisResult) -> str:
         """Generate C++ header file."""
         header = """#pragma once
 
@@ -104,7 +104,7 @@ namespace pytocpp {
 
 """
         # Add function declarations
-        for func_name, func_info in analysis_result.get('functions', {}).items():
+        for func_name, func_info in analysis_result.type_info.items():
             if func_name.startswith('calculate_'):
                 # Get return type
                 return_type = func_info.get('return_type', 'int')
@@ -118,7 +118,7 @@ namespace pytocpp {
         header += "} // namespace pytocpp\n"
         return header
     
-    def _generate_implementation(self, analysis_result: Dict) -> str:
+    def _generate_implementation(self, analysis_result: AnalysisResult) -> str:
         """Generate C++ implementation file."""
         impl = """#include "generated.hpp"
 #include <vector>
@@ -133,7 +133,7 @@ namespace pytocpp {
 
 """
         # Add function implementations
-        for func_name, func_info in analysis_result.get('functions', {}).items():
+        for func_name, func_info in analysis_result.type_info.items():
             if func_name.startswith('calculate_'):
                 impl += self._generate_function_impl(func_name, func_info)
 

--- a/src/converter/code_generator_fixed.py
+++ b/src/converter/code_generator_fixed.py
@@ -1043,6 +1043,10 @@ namespace pytocpp {
                     obj = self._translate_expression(node.func.value.value, local_vars)
                     args = [self._translate_expression(arg, local_vars) for arg in node.args]
                     return f"{obj}.push_back({', '.join(args)})"
+                elif func_name in ['sqrt', 'sin', 'cos']:
+                    # math functions imported directly
+                    args = [self._translate_expression(arg, local_vars) for arg in node.args]
+                    return f"std::{func_name}({', '.join(args)})"
                 else:
                     # Regular function call
                     args = [self._translate_expression(arg, local_vars) for arg in node.args]
@@ -1057,6 +1061,9 @@ namespace pytocpp {
                     method = 'push_back'  # std::vector uses push_back, not append
                 
                 args = [self._translate_expression(arg, local_vars) for arg in node.args]
+                # Map math module functions to std:: equivalents
+                if obj == 'math' and method in ['sqrt', 'sin', 'cos']:
+                    return f"std::{method}({', '.join(args)})"
                 return f"{obj}.{method}({', '.join(args)})"
             else:
                 # Fallback for other callable expressions

--- a/tests/test_math_function_conversion.py
+++ b/tests/test_math_function_conversion.py
@@ -1,0 +1,21 @@
+import ast
+from src.converter.code_generator_fixed import CodeGenerator
+from src.rules.rule_manager import RuleManager
+
+
+def translate(expr: str) -> str:
+    node = ast.parse(expr).body[0].value
+    generator = CodeGenerator(RuleManager())
+    return generator._translate_expression(node, {})
+
+
+def test_sqrt_translation():
+    assert translate('math.sqrt(4)') == 'std::sqrt(4)'
+
+
+def test_sin_translation():
+    assert translate('math.sin(x)') == 'std::sin(x)'
+
+
+def test_cos_translation():
+    assert translate('math.cos(y)') == 'std::cos(y)'


### PR DESCRIPTION
## Summary
- handle `math.sqrt`, `math.sin`, and `math.cos` in `_translate_expression`
- document mapping of Python math functions to C++
- add unit tests for translation logic
- fix tuple handling in analyzer to keep existing tests passing
- allow `CodeGenerator` to work with `AnalysisResult` objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a54c634f88332b7b2c21417de16a4